### PR TITLE
Added missing parameter to the example .env

### DIFF
--- a/melodia-backend/.env.example
+++ b/melodia-backend/.env.example
@@ -13,5 +13,7 @@ MONGODB_URI=mongodb://localhost:27017/melodia
 JWT_SECRET=replace_with_a_long_random_secret
 
 # Generated using:
+# IMPORTANT!!! Generate TWICE and DON'T use the same hex secret for both
 # node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+SPOTIFY_TOKEN_ENCRYPTION_KEY=replace_with_a_64_character_hex_secret
 SPOTIFY_TOKEN_ENCRYPTION_KEY=replace_with_a_64_character_hex_secret


### PR DESCRIPTION
## What changed?

Added following parameter to the example .env: SPOTIFY_TOKEN_ENCRYPTION_KEY

## How was it tested?

No testing needed

## Related issue

Fixes -
